### PR TITLE
Initial Dev Container work

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+LABEL maintainer="Daniel Philipov <dp33@illinois.edu>"
+
+######################################################
+#               Install System Dependencies          #
+######################################################
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y git curl make
+
+######################################################
+#               Install Rust and Cargo               #
+######################################################
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# ######################################################
+#         Install Python and Dependencies            #
+######################################################
+
+RUN apt-get install -y python3.10 python3-pip 
+RUN pip3 install --upgrade pip
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt
+

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:22.04
 
 LABEL maintainer="Daniel Philipov <dp33@illinois.edu>"
 
+SHELL ["/bin/bash", "-c"]
+
 ######################################################
 #               Install System Dependencies          #
 ######################################################
@@ -16,13 +18,17 @@ RUN apt-get install -y git curl make
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# ######################################################
+#######################################################
 #         Install Python and Dependencies            #
 ######################################################
 
 RUN apt-get install -y python3.10 python3-pip 
+RUN echo "alias python=python3" >> ~/.bashrc
 RUN pip3 install --upgrade pip
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
 
+#######################################################
+
+RUN source ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "PredictivePilot",
+    "build": {
+        "dockerfile": "Dockerfile",
+    },
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,4 +3,20 @@
     "build": {
         "dockerfile": "Dockerfile",
     },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "serayuzgur.crates",
+                "ms-azuretools.vscode-docker",
+                "tamasfe.even-better-toml",
+                "ms-python.vscode-pylance",
+                "ms-python.python",
+                "ms-python.debugpy",
+                "rust-lang.rust-analyzer",
+                "cweijan.vscode-mysql-client2",
+                "Oracle.mysql-shell-for-vs-code",
+                "jinxdash.prettier-rust"
+            ]
+        }
+    },
 }

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -5,5 +5,6 @@ numpy == 1.26.0
 scipy == 1.12.0
 scikit-learn == 1.4.0
 
-
 # Alexandra's dependencies
+pandas == 2.2.0
+mysql-connector-python == 8.3.0

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,9 @@
+# Python dependencies for the project
+
+# Akshay's dependencies
+numpy == 1.26.0
+scipy == 1.12.0
+scikit-learn == 1.4.0
+
+
+# Alexandra's dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust post-build files
 /target
+Cargo.lock
 
 # IDE Configuration files
 .idea/
@@ -7,3 +8,4 @@
 
 # MacOS files
 .DS_Store
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "PredictivePilot"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 authors = [
     "Sohum Sharma <sohums3@illinois.edu>", 
     "Daniel Philipov <dp33@illinois.edu>", 
@@ -11,8 +11,7 @@ authors = [
 
 rust-version = "1.76.0"
 
-
-description = "An Applet to assist with choosing the best model for a given dataset"
+description = "An Applet to assist with choosing the best model for a given dataset."
 readme = "README.md"
 
 repository = "https://github.com/sohumsharma484/PredictivePilot"


### PR DESCRIPTION
I created a docker environment that standardizes all the dependencies for this project. It will build locally upon a user opening the project and selecting to reopen in dev environment in VSCode. Everything is done locally to decrease complexity of maintaining the devcontainer, as pushing to docker hub would add more steps to the process.

I also included some VSCode extensions that I think are useful for this project. Any comments or suggestions are appreciated for extensions of your choice.

For Python package management, libraries and their versions are listed in requirements.txt, and users can add their packages to the txt and rebuild the devcontainer to get them. I have locked their versions as of now to ensure that nothing breaks as a result of changes to the libraries.

For Rust packages, cargo will automatically download and build them based on the versions and packages specified in the Cargo.toml, so there is no need to manually add them in the docker, as it may lead to a disconnect in packages specified in the docker and in the Cargo.toml.

Also, I accidentally broke something in the Cargo.toml when I initially committed (oops, I set edition to 2024, but it must be 2021). That is fixed now.

For now, there are linker issues on arm architecture, but only I use arm, and I just set the docker to build in amd64 as of 30 seconds after hitting push (sorry). It should not affect any other project users, as everyone else uses windows, which is amd64 (a.k.a. x86-64).